### PR TITLE
Refactor registration sample into DDD solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+.vs/
+**/bin/
+**/obj/
+**/.vs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# ChatgptTest
+# Registration Demo
+
+این مخزن یک نمونه‌ی کامل از معماری لایه‌ای مبتنی بر Domain Driven Design برای یک فرم ثبت‌نام تحت وب است که با ‎.NET 9‎ و Razor Pages پیاده‌سازی شده است. اعتبارسنجی دامنه در سمت سرور انجام می‌شود و خروجی تمیز به صورت JSON به فرانت‌اند برگردانده می‌شود تا در ‎localStorage‎ مرورگر نگهداری شود.
+
+## ساختار راه‌حل
+
+```
+ChatgptTest/
+├── RegistrationApp.sln
+├── src/
+│   ├── RegistrationApp.Domain/        ← موجودیت‌ها، Value Objectها و منطق دامنه
+│   ├── RegistrationApp.Application/   ← سرویس‌های کاربردی و DTO ها
+│   ├── RegistrationApp.Infrastructure/← پیاده‌سازی وابستگی‌ها (Clock، تعریف فرم و ...)
+│   └── RegistrationApp.Web/           ← لایه‌ی نمایش Razor Pages و اسکریپت‌های سمت کلاینت
+```
+
+## اجرای پروژه
+
+1. پیش‌نیازها: نصب ‎.NET 9 SDK‎.
+2. بیلد و اجرای پروژه‌ی وب:
+
+```bash
+dotnet build RegistrationApp.sln
+dotnet run --project src/RegistrationApp.Web/RegistrationApp.Web.csproj
+```
+
+در صورت اجرای پروژه، صفحه‌ی ثبت‌نام در آدرس `https://localhost:5001` (یا پورتی که در خروجی `dotnet run` اعلام می‌شود) در دسترس خواهد بود.
+
+## قابلیت‌ها
+
+- اعتبارسنجی کامل اطلاعات کاربر مطابق قواعد دامنه (نام، ایمیل، تاریخ تولد و ...).
+- ذخیره‌ی رکوردهای تأیید شده در ‎localStorage‎ مرورگر همراه با جدول پویا و آمار رکوردها.
+- ساختار ماژولار با DI و سرویس‌های قابل تست و قابل توسعه.

--- a/RegistrationApp.sln
+++ b/RegistrationApp.sln
@@ -1,0 +1,42 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistrationApp.Domain", "src/RegistrationApp.Domain/RegistrationApp.Domain.csproj", "{C6B70A5D-25CF-45FB-BC30-E70C1F5F61BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistrationApp.Application", "src/RegistrationApp.Application/RegistrationApp.Application.csproj", "{A4C2280F-9F82-41A8-8FCA-0D814D0E86CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistrationApp.Infrastructure", "src/RegistrationApp.Infrastructure/RegistrationApp.Infrastructure.csproj", "{7D68248C-D88A-4275-982C-440D5B63E11D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistrationApp.Web", "src/RegistrationApp.Web/RegistrationApp.Web.csproj", "{B883CD11-9786-4C31-9756-F9308EF914C5}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {C6B70A5D-25CF-45FB-BC30-E70C1F5F61BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {C6B70A5D-25CF-45FB-BC30-E70C1F5F61BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {C6B70A5D-25CF-45FB-BC30-E70C1F5F61BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {C6B70A5D-25CF-45FB-BC30-E70C1F5F61BD}.Release|Any CPU.Build.0 = Release|Any CPU
+        {A4C2280F-9F82-41A8-8FCA-0D814D0E86CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A4C2280F-9F82-41A8-8FCA-0D814D0E86CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A4C2280F-9F82-41A8-8FCA-0D814D0E86CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A4C2280F-9F82-41A8-8FCA-0D814D0E86CB}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7D68248C-D88A-4275-982C-440D5B63E11D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7D68248C-D88A-4275-982C-440D5B63E11D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7D68248C-D88A-4275-982C-440D5B63E11D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7D68248C-D88A-4275-982C-440D5B63E11D}.Release|Any CPU.Build.0 = Release|Any CPU
+        {B883CD11-9786-4C31-9756-F9308EF914C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B883CD11-9786-4C31-9756-F9308EF914C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B883CD11-9786-4C31-9756-F9308EF914C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B883CD11-9786-4C31-9756-F9308EF914C5}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {781E86A4-386A-49F9-991D-565986073662}
+    EndGlobalSection
+EndGlobal

--- a/src/RegistrationApp.Application/Abstractions/IRegistrationFormDefinitionProvider.cs
+++ b/src/RegistrationApp.Application/Abstractions/IRegistrationFormDefinitionProvider.cs
@@ -1,0 +1,8 @@
+using RegistrationApp.Application.Contracts.Forms;
+
+namespace RegistrationApp.Application.Abstractions;
+
+public interface IRegistrationFormDefinitionProvider
+{
+    RegistrationFormDefinition GetDefinition();
+}

--- a/src/RegistrationApp.Application/Abstractions/IRegistrationService.cs
+++ b/src/RegistrationApp.Application/Abstractions/IRegistrationService.cs
@@ -1,0 +1,8 @@
+using RegistrationApp.Application.Contracts.Registrations;
+
+namespace RegistrationApp.Application.Abstractions;
+
+public interface IRegistrationService
+{
+    RegistrationResult ValidateAndCreateRecord(RegistrationRequest request);
+}

--- a/src/RegistrationApp.Application/Contracts/Forms/FormFieldDefinition.cs
+++ b/src/RegistrationApp.Application/Contracts/Forms/FormFieldDefinition.cs
@@ -1,0 +1,24 @@
+namespace RegistrationApp.Application.Contracts.Forms;
+
+public sealed class FormFieldDefinition
+{
+    public required string Id { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string Label { get; init; }
+
+    public required string Type { get; init; }
+
+    public bool IsRequired { get; init; }
+
+    public string? Placeholder { get; init; }
+
+    public string? HelpText { get; init; }
+
+    public int ColumnSpan { get; init; } = 12;
+
+    public IReadOnlyList<FormFieldOption> Options { get; init; } = Array.Empty<FormFieldOption>();
+
+    public string? CssClass { get; init; }
+}

--- a/src/RegistrationApp.Application/Contracts/Forms/FormFieldOption.cs
+++ b/src/RegistrationApp.Application/Contracts/Forms/FormFieldOption.cs
@@ -1,0 +1,3 @@
+namespace RegistrationApp.Application.Contracts.Forms;
+
+public sealed record FormFieldOption(string Value, string Label);

--- a/src/RegistrationApp.Application/Contracts/Forms/FormSectionDefinition.cs
+++ b/src/RegistrationApp.Application/Contracts/Forms/FormSectionDefinition.cs
@@ -1,0 +1,10 @@
+namespace RegistrationApp.Application.Contracts.Forms;
+
+public sealed class FormSectionDefinition
+{
+    public required string Title { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<FormFieldDefinition> Fields { get; init; } = Array.Empty<FormFieldDefinition>();
+}

--- a/src/RegistrationApp.Application/Contracts/Forms/RegistrationFormDefinition.cs
+++ b/src/RegistrationApp.Application/Contracts/Forms/RegistrationFormDefinition.cs
@@ -1,0 +1,10 @@
+namespace RegistrationApp.Application.Contracts.Forms;
+
+public sealed class RegistrationFormDefinition
+{
+    public required string Title { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<FormSectionDefinition> Sections { get; init; } = Array.Empty<FormSectionDefinition>();
+}

--- a/src/RegistrationApp.Application/Contracts/Registrations/RegistrationRecordDto.cs
+++ b/src/RegistrationApp.Application/Contracts/Registrations/RegistrationRecordDto.cs
@@ -1,0 +1,28 @@
+namespace RegistrationApp.Application.Contracts.Registrations;
+
+public sealed class RegistrationRecordDto
+{
+    public Guid Id { get; init; }
+
+    public required string FirstName { get; init; }
+
+    public required string LastName { get; init; }
+
+    public required string FullName { get; init; }
+
+    public required string Email { get; init; }
+
+    public string? PhoneNumber { get; init; }
+
+    public string? BirthDate { get; init; }
+
+    public string? GenderKey { get; init; }
+
+    public string? GenderDisplayName { get; init; }
+
+    public string? City { get; init; }
+
+    public string? Address { get; init; }
+
+    public required string CreatedAt { get; init; }
+}

--- a/src/RegistrationApp.Application/Contracts/Registrations/RegistrationRequest.cs
+++ b/src/RegistrationApp.Application/Contracts/Registrations/RegistrationRequest.cs
@@ -1,0 +1,20 @@
+namespace RegistrationApp.Application.Contracts.Registrations;
+
+public sealed class RegistrationRequest
+{
+    public string? FirstName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public string? Email { get; set; }
+
+    public string? PhoneNumber { get; set; }
+
+    public string? BirthDate { get; set; }
+
+    public string? Gender { get; set; }
+
+    public string? City { get; set; }
+
+    public string? Address { get; set; }
+}

--- a/src/RegistrationApp.Application/Contracts/Registrations/RegistrationResult.cs
+++ b/src/RegistrationApp.Application/Contracts/Registrations/RegistrationResult.cs
@@ -1,0 +1,37 @@
+namespace RegistrationApp.Application.Contracts.Registrations;
+
+public sealed class RegistrationResult
+{
+    private RegistrationResult(RegistrationRecordDto record)
+    {
+        Record = record;
+        Errors = Array.Empty<ValidationErrorDto>();
+        Succeeded = true;
+    }
+
+    private RegistrationResult(IReadOnlyCollection<ValidationErrorDto> errors)
+    {
+        Errors = errors;
+    }
+
+    public bool Succeeded { get; }
+
+    public bool Failed => !Succeeded;
+
+    public RegistrationRecordDto? Record { get; }
+
+    public IReadOnlyCollection<ValidationErrorDto> Errors { get; } = Array.Empty<ValidationErrorDto>();
+
+    public static RegistrationResult Success(RegistrationRecordDto record) => new(record);
+
+    public static RegistrationResult Failure(IEnumerable<ValidationErrorDto> errors)
+    {
+        var materialized = errors.ToArray();
+        if (materialized.Length == 0)
+        {
+            throw new ArgumentException("Errors collection cannot be empty for a failure result.", nameof(errors));
+        }
+
+        return new RegistrationResult(materialized);
+    }
+}

--- a/src/RegistrationApp.Application/Contracts/Registrations/ValidationErrorDto.cs
+++ b/src/RegistrationApp.Application/Contracts/Registrations/ValidationErrorDto.cs
@@ -1,0 +1,3 @@
+namespace RegistrationApp.Application.Contracts.Registrations;
+
+public sealed record ValidationErrorDto(string Code, string Message);

--- a/src/RegistrationApp.Application/DependencyInjection.cs
+++ b/src/RegistrationApp.Application/DependencyInjection.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Application.Services;
+
+namespace RegistrationApp.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<IRegistrationService, RegistrationService>();
+        return services;
+    }
+}

--- a/src/RegistrationApp.Application/RegistrationApp.Application.csproj
+++ b/src/RegistrationApp.Application/RegistrationApp.Application.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RegistrationApp.Domain\RegistrationApp.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/RegistrationApp.Application/Services/RegistrationService.cs
+++ b/src/RegistrationApp.Application/Services/RegistrationService.cs
@@ -1,0 +1,81 @@
+using System.Globalization;
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Application.Contracts.Registrations;
+using RegistrationApp.Domain.Abstractions;
+using RegistrationApp.Domain.Common;
+using RegistrationApp.Domain.Registrations;
+
+namespace RegistrationApp.Application.Services;
+
+public sealed class RegistrationService : IRegistrationService
+{
+    private readonly IClock _clock;
+
+    public RegistrationService(IClock clock)
+    {
+        _clock = clock;
+    }
+
+    public RegistrationResult ValidateAndCreateRecord(RegistrationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var birthDateResult = ParseBirthDate(request.BirthDate);
+        if (birthDateResult.IsFailure)
+        {
+            return RegistrationResult.Failure(birthDateResult.Errors.Select(error => new ValidationErrorDto(error.Code, error.Message)));
+        }
+
+        var domainResult = Registrant.Create(
+            request.FirstName,
+            request.LastName,
+            request.Email,
+            request.PhoneNumber,
+            request.Gender,
+            request.City,
+            request.Address,
+            birthDateResult.Value,
+            _clock);
+
+        if (domainResult.IsFailure)
+        {
+            return RegistrationResult.Failure(domainResult.Errors.Select(error => new ValidationErrorDto(error.Code, error.Message)));
+        }
+
+        var registrant = domainResult.Value!;
+
+        return RegistrationResult.Success(new RegistrationRecordDto
+        {
+            Id = registrant.Id,
+            FirstName = registrant.Name.FirstName,
+            LastName = registrant.Name.LastName,
+            FullName = registrant.Name.FullName,
+            Email = registrant.Email.Value,
+            PhoneNumber = registrant.PhoneNumber?.Value,
+            BirthDate = registrant.BirthDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            GenderKey = registrant.Gender?.Key,
+            GenderDisplayName = registrant.Gender?.DisplayName,
+            City = registrant.Address?.City,
+            Address = registrant.Address?.FullAddress,
+            CreatedAt = registrant.CreatedAt.ToString("O", CultureInfo.InvariantCulture)
+        });
+    }
+
+    private static ValidationResult<DateOnly?> ParseBirthDate(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ValidationResult<DateOnly?>.Success(null);
+        }
+
+        if (DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var birthDate))
+        {
+            return ValidationResult<DateOnly?>.Success(birthDate);
+        }
+
+        return ValidationResult<DateOnly?>.Failure(new[]
+        {
+            ValidationError.Create("BirthDate.Invalid", "قالب تاریخ تولد معتبر نیست."),
+        });
+    }
+}

--- a/src/RegistrationApp.Domain/Abstractions/IClock.cs
+++ b/src/RegistrationApp.Domain/Abstractions/IClock.cs
@@ -1,0 +1,6 @@
+namespace RegistrationApp.Domain.Abstractions;
+
+public interface IClock
+{
+    DateTimeOffset UtcNow { get; }
+}

--- a/src/RegistrationApp.Domain/Common/ValidationError.cs
+++ b/src/RegistrationApp.Domain/Common/ValidationError.cs
@@ -1,0 +1,6 @@
+namespace RegistrationApp.Domain.Common;
+
+public sealed record ValidationError(string Code, string Message)
+{
+    public static ValidationError Create(string code, string message) => new(code, message);
+}

--- a/src/RegistrationApp.Domain/Common/ValidationResult.cs
+++ b/src/RegistrationApp.Domain/Common/ValidationResult.cs
@@ -1,0 +1,37 @@
+namespace RegistrationApp.Domain.Common;
+
+public sealed class ValidationResult<T>
+{
+    private ValidationResult(T value)
+    {
+        IsSuccess = true;
+        Value = value;
+        Errors = Array.Empty<ValidationError>();
+    }
+
+    private ValidationResult(IReadOnlyCollection<ValidationError> errors)
+    {
+        Errors = errors;
+    }
+
+    public bool IsSuccess { get; }
+
+    public bool IsFailure => !IsSuccess;
+
+    public T? Value { get; }
+
+    public IReadOnlyCollection<ValidationError> Errors { get; } = Array.Empty<ValidationError>();
+
+    public static ValidationResult<T> Success(T value) => new(value);
+
+    public static ValidationResult<T> Failure(IEnumerable<ValidationError> errors)
+    {
+        var errorArray = errors.ToArray();
+        if (errorArray.Length == 0)
+        {
+            throw new ArgumentException("At least one error is required for a failure result.", nameof(errors));
+        }
+
+        return new ValidationResult<T>(errorArray);
+    }
+}

--- a/src/RegistrationApp.Domain/RegistrationApp.Domain.csproj
+++ b/src/RegistrationApp.Domain/RegistrationApp.Domain.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/RegistrationApp.Domain/Registrations/Registrant.cs
+++ b/src/RegistrationApp.Domain/Registrations/Registrant.cs
@@ -1,0 +1,118 @@
+using RegistrationApp.Domain.Abstractions;
+using RegistrationApp.Domain.Common;
+using RegistrationApp.Domain.Registrations.ValueObjects;
+
+namespace RegistrationApp.Domain.Registrations;
+
+public sealed class Registrant
+{
+    private Registrant(
+        Guid id,
+        PersonalName name,
+        EmailAddress email,
+        PhoneNumber? phoneNumber,
+        Gender? gender,
+        Address? address,
+        DateOnly? birthDate,
+        DateTimeOffset createdAt)
+    {
+        Id = id;
+        Name = name;
+        Email = email;
+        PhoneNumber = phoneNumber;
+        Gender = gender;
+        Address = address;
+        BirthDate = birthDate;
+        CreatedAt = createdAt;
+    }
+
+    public Guid Id { get; }
+
+    public PersonalName Name { get; }
+
+    public EmailAddress Email { get; }
+
+    public PhoneNumber? PhoneNumber { get; }
+
+    public Gender? Gender { get; }
+
+    public Address? Address { get; }
+
+    public DateOnly? BirthDate { get; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    public static ValidationResult<Registrant> Create(
+        string? firstName,
+        string? lastName,
+        string? email,
+        string? phoneNumber,
+        string? gender,
+        string? city,
+        string? address,
+        DateOnly? birthDate,
+        IClock clock)
+    {
+        ArgumentNullException.ThrowIfNull(clock);
+
+        var errors = new List<ValidationError>();
+
+        var nameResult = PersonalName.Create(firstName, lastName);
+        if (nameResult.IsFailure)
+        {
+            errors.AddRange(nameResult.Errors);
+        }
+
+        var emailResult = EmailAddress.Create(email);
+        if (emailResult.IsFailure)
+        {
+            errors.AddRange(emailResult.Errors);
+        }
+
+        var phoneResult = PhoneNumber.CreateOptional(phoneNumber);
+        if (phoneResult.IsFailure)
+        {
+            errors.AddRange(phoneResult.Errors);
+        }
+
+        var genderResult = Gender.CreateOptional(gender);
+        if (genderResult.IsFailure)
+        {
+            errors.AddRange(genderResult.Errors);
+        }
+
+        var addressResult = Address.CreateOptional(city, address);
+        if (addressResult.IsFailure)
+        {
+            errors.AddRange(addressResult.Errors);
+        }
+
+        if (birthDate is { } birth)
+        {
+            var today = DateOnly.FromDateTime(clock.UtcNow.Date);
+            if (birth > today)
+            {
+                errors.Add(ValidationError.Create("BirthDate.Future", "تاریخ تولد نمی‌تواند در آینده باشد."));
+            }
+            else if (birth < today.AddYears(-120))
+            {
+                errors.Add(ValidationError.Create("BirthDate.TooOld", "تاریخ تولد وارد شده معتبر نیست."));
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            return ValidationResult<Registrant>.Failure(errors);
+        }
+
+        return ValidationResult<Registrant>.Success(new Registrant(
+            Guid.NewGuid(),
+            nameResult.Value!,
+            emailResult.Value!,
+            phoneResult.Value,
+            genderResult.Value,
+            addressResult.Value,
+            birthDate,
+            clock.UtcNow));
+    }
+}

--- a/src/RegistrationApp.Domain/Registrations/ValueObjects/Address.cs
+++ b/src/RegistrationApp.Domain/Registrations/ValueObjects/Address.cs
@@ -1,0 +1,46 @@
+using RegistrationApp.Domain.Common;
+
+namespace RegistrationApp.Domain.Registrations.ValueObjects;
+
+public sealed class Address
+{
+    private Address(string? city, string? fullAddress)
+    {
+        City = city;
+        FullAddress = fullAddress;
+    }
+
+    public string? City { get; }
+
+    public string? FullAddress { get; }
+
+    public static ValidationResult<Address?> CreateOptional(string? city, string? fullAddress)
+    {
+        var trimmedCity = string.IsNullOrWhiteSpace(city) ? null : city.Trim();
+        var trimmedAddress = string.IsNullOrWhiteSpace(fullAddress) ? null : fullAddress.Trim();
+
+        var errors = new List<ValidationError>();
+
+        if (trimmedCity is { Length: > 100 })
+        {
+            errors.Add(ValidationError.Create("Address.City.Length", "نام شهر نباید بیش از ۱۰۰ کاراکتر باشد."));
+        }
+
+        if (trimmedAddress is { Length: > 500 })
+        {
+            errors.Add(ValidationError.Create("Address.Full.Length", "آدرس نباید بیش از ۵۰۰ کاراکتر باشد."));
+        }
+
+        if (errors.Count > 0)
+        {
+            return ValidationResult<Address?>.Failure(errors);
+        }
+
+        if (trimmedCity is null && trimmedAddress is null)
+        {
+            return ValidationResult<Address?>.Success(null);
+        }
+
+        return ValidationResult<Address?>.Success(new Address(trimmedCity, trimmedAddress));
+    }
+}

--- a/src/RegistrationApp.Domain/Registrations/ValueObjects/EmailAddress.cs
+++ b/src/RegistrationApp.Domain/Registrations/ValueObjects/EmailAddress.cs
@@ -1,0 +1,49 @@
+using System.Net.Mail;
+using RegistrationApp.Domain.Common;
+
+namespace RegistrationApp.Domain.Registrations.ValueObjects;
+
+public sealed class EmailAddress
+{
+    private EmailAddress(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public static ValidationResult<EmailAddress> Create(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ValidationResult<EmailAddress>.Failure(new[]
+            {
+                ValidationError.Create("Email.Empty", "ایمیل باید وارد شود."),
+            });
+        }
+
+        var trimmed = value.Trim();
+
+        try
+        {
+            _ = new MailAddress(trimmed);
+        }
+        catch (FormatException)
+        {
+            return ValidationResult<EmailAddress>.Failure(new[]
+            {
+                ValidationError.Create("Email.Invalid", "ایمیل وارد شده معتبر نیست."),
+            });
+        }
+
+        if (trimmed.Length > 200)
+        {
+            return ValidationResult<EmailAddress>.Failure(new[]
+            {
+                ValidationError.Create("Email.Length", "ایمیل نباید بیش از ۲۰۰ کاراکتر باشد."),
+            });
+        }
+
+        return ValidationResult<EmailAddress>.Success(new EmailAddress(trimmed));
+    }
+}

--- a/src/RegistrationApp.Domain/Registrations/ValueObjects/Gender.cs
+++ b/src/RegistrationApp.Domain/Registrations/ValueObjects/Gender.cs
@@ -1,0 +1,48 @@
+using RegistrationApp.Domain.Common;
+
+namespace RegistrationApp.Domain.Registrations.ValueObjects;
+
+public sealed class Gender
+{
+    private static readonly IReadOnlyDictionary<string, string> SupportedValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["female"] = "زن",
+        ["male"] = "مرد",
+        ["other"] = "سایر",
+    };
+
+    private Gender(string key, string displayName)
+    {
+        Key = key;
+        DisplayName = displayName;
+    }
+
+    public string Key { get; }
+
+    public string DisplayName { get; }
+
+    public static ValidationResult<Gender?> CreateOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ValidationResult<Gender?>.Success(null);
+        }
+
+        var normalized = value.Trim();
+
+        var match = SupportedValues
+            .FirstOrDefault(pair => string.Equals(pair.Value, normalized, StringComparison.OrdinalIgnoreCase) || string.Equals(pair.Key, normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (string.IsNullOrEmpty(match.Key))
+        {
+            return ValidationResult<Gender?>.Failure(new[]
+            {
+                ValidationError.Create("Gender.Invalid", "گزینه‌ی انتخاب شده برای جنسیت معتبر نیست."),
+            });
+        }
+
+        return ValidationResult<Gender?>.Success(new Gender(match.Key, match.Value));
+    }
+
+    public static IReadOnlyDictionary<string, string> GetDisplayOptions() => SupportedValues;
+}

--- a/src/RegistrationApp.Domain/Registrations/ValueObjects/PersonalName.cs
+++ b/src/RegistrationApp.Domain/Registrations/ValueObjects/PersonalName.cs
@@ -1,0 +1,48 @@
+using RegistrationApp.Domain.Common;
+
+namespace RegistrationApp.Domain.Registrations.ValueObjects;
+
+public sealed class PersonalName
+{
+    private PersonalName(string firstName, string lastName)
+    {
+        FirstName = firstName;
+        LastName = lastName;
+    }
+
+    public string FirstName { get; }
+
+    public string LastName { get; }
+
+    public string FullName => string.Join(' ', new[] { FirstName, LastName }.Where(x => !string.IsNullOrWhiteSpace(x)));
+
+    public static ValidationResult<PersonalName> Create(string? firstName, string? lastName)
+    {
+        var errors = new List<ValidationError>();
+
+        var trimmedFirstName = firstName?.Trim() ?? string.Empty;
+        var trimmedLastName = lastName?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(trimmedFirstName))
+        {
+            errors.Add(ValidationError.Create("Name.FirstName.Empty", "نام باید وارد شود."));
+        }
+        else if (trimmedFirstName.Length is < 2 or > 100)
+        {
+            errors.Add(ValidationError.Create("Name.FirstName.Length", "نام باید بین ۲ تا ۱۰۰ کاراکتر باشد."));
+        }
+
+        if (string.IsNullOrWhiteSpace(trimmedLastName))
+        {
+            errors.Add(ValidationError.Create("Name.LastName.Empty", "نام خانوادگی باید وارد شود."));
+        }
+        else if (trimmedLastName.Length is < 2 or > 100)
+        {
+            errors.Add(ValidationError.Create("Name.LastName.Length", "نام خانوادگی باید بین ۲ تا ۱۰۰ کاراکتر باشد."));
+        }
+
+        return errors.Count > 0
+            ? ValidationResult<PersonalName>.Failure(errors)
+            : ValidationResult<PersonalName>.Success(new PersonalName(trimmedFirstName, trimmedLastName));
+    }
+}

--- a/src/RegistrationApp.Domain/Registrations/ValueObjects/PhoneNumber.cs
+++ b/src/RegistrationApp.Domain/Registrations/ValueObjects/PhoneNumber.cs
@@ -1,0 +1,36 @@
+using System.Text.RegularExpressions;
+using RegistrationApp.Domain.Common;
+
+namespace RegistrationApp.Domain.Registrations.ValueObjects;
+
+public sealed class PhoneNumber
+{
+    private static readonly Regex DigitsRegex = new("^[0-9]{10,15}$", RegexOptions.Compiled);
+
+    private PhoneNumber(string value)
+    {
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public static ValidationResult<PhoneNumber?> CreateOptional(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return ValidationResult<PhoneNumber?>.Success(null);
+        }
+
+        var normalized = value.Trim().Replace(" ", string.Empty).Replace("-", string.Empty);
+
+        if (!DigitsRegex.IsMatch(normalized))
+        {
+            return ValidationResult<PhoneNumber?>.Failure(new[]
+            {
+                ValidationError.Create("PhoneNumber.Invalid", "شماره تماس باید بین ۱۰ تا ۱۵ رقم و فقط شامل اعداد باشد."),
+            });
+        }
+
+        return ValidationResult<PhoneNumber?>.Success(new PhoneNumber(normalized));
+    }
+}

--- a/src/RegistrationApp.Infrastructure/DependencyInjection.cs
+++ b/src/RegistrationApp.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.DependencyInjection;
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Domain.Abstractions;
+using RegistrationApp.Infrastructure.Registrations;
+using RegistrationApp.Infrastructure.Time;
+
+namespace RegistrationApp.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
+    {
+        services.AddSingleton<IClock, SystemClock>();
+        services.AddSingleton<IRegistrationFormDefinitionProvider, RegistrationFormDefinitionProvider>();
+        return services;
+    }
+}

--- a/src/RegistrationApp.Infrastructure/RegistrationApp.Infrastructure.csproj
+++ b/src/RegistrationApp.Infrastructure/RegistrationApp.Infrastructure.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RegistrationApp.Application\RegistrationApp.Application.csproj" />
+    <ProjectReference Include="..\RegistrationApp.Domain\RegistrationApp.Domain.csproj" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/RegistrationApp.Infrastructure/Registrations/RegistrationFormDefinitionProvider.cs
+++ b/src/RegistrationApp.Infrastructure/Registrations/RegistrationFormDefinitionProvider.cs
@@ -1,0 +1,108 @@
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Application.Contracts.Forms;
+using RegistrationApp.Domain.Registrations.ValueObjects;
+
+namespace RegistrationApp.Infrastructure.Registrations;
+
+public sealed class RegistrationFormDefinitionProvider : IRegistrationFormDefinitionProvider
+{
+    public RegistrationFormDefinition GetDefinition()
+    {
+        var genderOptions = Gender.GetDisplayOptions()
+            .Select(option => new FormFieldOption(option.Key, option.Value))
+            .ToList();
+
+        var personalSection = new FormSectionDefinition
+        {
+            Title = "اطلاعات فردی",
+            Description = "فرم زیر را تکمیل کنید تا در حافظه‌ی مرورگر ذخیره شود.",
+            Fields = new List<FormFieldDefinition>
+            {
+                new()
+                {
+                    Id = "firstName",
+                    Name = "firstName",
+                    Label = "نام",
+                    Type = "text",
+                    IsRequired = true,
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "lastName",
+                    Name = "lastName",
+                    Label = "نام خانوادگی",
+                    Type = "text",
+                    IsRequired = true,
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "email",
+                    Name = "email",
+                    Label = "ایمیل",
+                    Type = "email",
+                    IsRequired = true,
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "phone",
+                    Name = "phone",
+                    Label = "شماره تماس",
+                    Type = "tel",
+                    Placeholder = "09xxxxxxxxx",
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "birthDate",
+                    Name = "birthDate",
+                    Label = "تاریخ تولد",
+                    Type = "date",
+                    ColumnSpan = 6,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "gender",
+                    Name = "gender",
+                    Label = "جنسیت",
+                    Type = "select",
+                    ColumnSpan = 6,
+                    CssClass = "mb-3",
+                    Options = new[] { new FormFieldOption(string.Empty, "انتخاب کنید") }.Concat(genderOptions).ToList(),
+                },
+                new()
+                {
+                    Id = "city",
+                    Name = "city",
+                    Label = "شهر",
+                    Type = "text",
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+                new()
+                {
+                    Id = "address",
+                    Name = "address",
+                    Label = "آدرس کامل",
+                    Type = "textarea",
+                    ColumnSpan = 12,
+                    CssClass = "mb-3",
+                },
+            }
+        };
+
+        return new RegistrationFormDefinition
+        {
+            Title = "ثبت‌نام",
+            Description = personalSection.Description,
+            Sections = new[] { personalSection }
+        };
+    }
+}

--- a/src/RegistrationApp.Infrastructure/Time/SystemClock.cs
+++ b/src/RegistrationApp.Infrastructure/Time/SystemClock.cs
@@ -1,0 +1,8 @@
+using RegistrationApp.Domain.Abstractions;
+
+namespace RegistrationApp.Infrastructure.Time;
+
+public sealed class SystemClock : IClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/src/RegistrationApp.Web/Pages/Error.cshtml
+++ b/src/RegistrationApp.Web/Pages/Error.cshtml
@@ -1,0 +1,16 @@
+@page
+@model ErrorModel
+@{
+    ViewData["Title"] = "خطا";
+}
+
+<h1 class="text-danger">خطایی رخ داده است</h1>
+<p class="text-muted">در صورت تکرار، لطفاً از اطلاعات ثبت شده خروجی بگیرید و با پشتیبانی تماس بگیرید.</p>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>کد پیگیری:</strong>
+        <code>@Model.RequestId</code>
+    </p>
+}

--- a/src/RegistrationApp.Web/Pages/Error.cshtml.cs
+++ b/src/RegistrationApp.Web/Pages/Error.cshtml.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace RegistrationApp.Web.Pages;
+
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+public sealed class ErrorModel : PageModel
+{
+    public string? RequestId { get; private set; }
+
+    public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    public void OnGet()
+    {
+        RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+    }
+}

--- a/src/RegistrationApp.Web/Pages/Index.cshtml
+++ b/src/RegistrationApp.Web/Pages/Index.cshtml
@@ -1,0 +1,111 @@
+@page
+@model IndexModel
+@using System.Text.Json
+@using System.Linq
+@using System.Collections.Generic
+@{
+    ViewData["Title"] = Model.FormDefinition.Title;
+    var section = Model.FormDefinition.Sections.FirstOrDefault();
+
+    List<List<FormFieldDefinition>> BuildRows(FormSectionDefinition? formSection)
+    {
+        var rows = new List<List<FormFieldDefinition>>();
+        if (formSection is null)
+        {
+            return rows;
+        }
+
+        var currentRow = new List<FormFieldDefinition>();
+        var currentSpan = 0;
+
+        foreach (var field in formSection.Fields)
+        {
+            var span = Math.Clamp(field.ColumnSpan, 1, 12);
+            if (currentSpan + span > 12 && currentRow.Count > 0)
+            {
+                rows.Add(currentRow);
+                currentRow = new List<FormFieldDefinition>();
+                currentSpan = 0;
+            }
+
+            currentRow.Add(field);
+            currentSpan += span;
+        }
+
+        if (currentRow.Count > 0)
+        {
+            rows.Add(currentRow);
+        }
+
+        return rows;
+    }
+
+    var rows = BuildRows(section);
+    var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+}
+
+<div class="row g-4">
+    <div class="col-12 col-lg-5">
+        <section class="form-section">
+            <h2 class="mb-0">@section?.Title</h2>
+            @if (!string.IsNullOrWhiteSpace(section?.Description))
+            {
+                <p class="text-muted mb-4">@section!.Description</p>
+            }
+
+            <form id="registration-form" class="needs-validation" novalidate data-endpoint="@Url.Content("~/api/registrations/validate")">
+                <div id="form-errors" class="alert alert-danger d-none" role="alert"></div>
+                @foreach (var row in rows)
+                {
+                    <div class="row">
+                        @foreach (var field in row)
+                        {
+                            var span = Math.Clamp(field.ColumnSpan, 1, 12);
+                            var columnClass = $"col-12 col-sm-{span}";
+                            <div class="@columnClass">
+                                @await Html.PartialAsync("_FormField", field)
+                            </div>
+                        }
+                    </div>
+                }
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">ذخیره پس از اعتبارسنجی</button>
+                    <button type="button" id="clear-storage" class="btn btn-outline-danger">حذف همه اطلاعات</button>
+                </div>
+            </form>
+        </section>
+    </div>
+
+    <div class="col-12 col-lg-7">
+        <section class="table-container h-100">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="fs-5 mb-0">لیست افراد ذخیره شده</h2>
+                <span id="record-count" class="badge text-bg-secondary">0</span>
+            </div>
+            <div class="table-responsive">
+                <table class="table align-middle" id="records-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">#</th>
+                            <th scope="col">نام و نام خانوادگی</th>
+                            <th scope="col">ایمیل</th>
+                            <th scope="col">شماره تماس</th>
+                            <th scope="col">شهر</th>
+                            <th scope="col">تاریخ ثبت</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <p id="no-records" class="text-center my-4">هیچ اطلاعاتی ذخیره نشده است.</p>
+        </section>
+    </div>
+</div>
+
+@section Scripts {
+    <script id="registration-form-definition" type="application/json">
+        @Html.Raw(JsonSerializer.Serialize(Model.FormDefinition, jsonOptions))
+    </script>
+    <script src="~/js/registration.js" asp-append-version="true"></script>
+}

--- a/src/RegistrationApp.Web/Pages/Index.cshtml.cs
+++ b/src/RegistrationApp.Web/Pages/Index.cshtml.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Application.Contracts.Forms;
+
+namespace RegistrationApp.Web.Pages;
+
+public sealed class IndexModel : PageModel
+{
+    private readonly IRegistrationFormDefinitionProvider _definitionProvider;
+    private readonly ILogger<IndexModel> _logger;
+
+    public IndexModel(IRegistrationFormDefinitionProvider definitionProvider, ILogger<IndexModel> logger)
+    {
+        _definitionProvider = definitionProvider;
+        _logger = logger;
+    }
+
+    public RegistrationFormDefinition FormDefinition { get; private set; } = default!;
+
+    public void OnGet()
+    {
+        FormDefinition = _definitionProvider.GetDefinition();
+        _logger.LogDebug("Registration form definition resolved with {FieldCount} fields", FormDefinition.Sections.Sum(section => section.Fields.Count));
+    }
+}

--- a/src/RegistrationApp.Web/Pages/Shared/_FormField.cshtml
+++ b/src/RegistrationApp.Web/Pages/Shared/_FormField.cshtml
@@ -1,0 +1,39 @@
+@model FormFieldDefinition
+@{
+    var wrapperClasses = string.Join(' ', new[] { "form-field", Model.CssClass }.Where(value => !string.IsNullOrWhiteSpace(value)));
+    var labelClasses = "form-label" + (Model.IsRequired ? " required" : string.Empty);
+    var invalidMessage = Model.Type switch
+    {
+        "email" => "ایمیل معتبر وارد کنید.",
+        "tel" => "شماره تماس معتبر وارد کنید.",
+        "date" => "تاریخ معتبر انتخاب کنید.",
+        _ => Model.IsRequired ? $"{Model.Label} را وارد کنید." : "مقدار وارد شده معتبر نیست.",
+    };
+}
+<div class="@wrapperClasses">
+    <label class="@labelClasses" for="@Model.Id">@Model.Label</label>
+    @switch (Model.Type)
+    {
+        case "textarea":
+            <textarea class="form-control" id="@Model.Id" name="@Model.Name" rows="3" placeholder="@Model.Placeholder" @(Model.IsRequired ? "required" : null)></textarea>
+            break;
+        case "select":
+            <select class="form-select" id="@Model.Id" name="@Model.Name" @(Model.IsRequired ? "required" : null)>
+                @foreach (var option in Model.Options)
+                {
+                    <option value="@option.Value">@option.Label</option>
+                }
+            </select>
+            break;
+        default:
+            <input type="@Model.Type" class="form-control" id="@Model.Id" name="@Model.Name" placeholder="@Model.Placeholder" @(Model.IsRequired ? "required" : null) />
+            break;
+    }
+
+    @if (!string.IsNullOrWhiteSpace(Model.HelpText))
+    {
+        <div class="form-text">@Model.HelpText</div>
+    }
+
+    <div class="invalid-feedback">@invalidMessage</div>
+</div>

--- a/src/RegistrationApp.Web/Pages/Shared/_Layout.cshtml
+++ b/src/RegistrationApp.Web/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="fa">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - RegistrationApp</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+</head>
+<body dir="rtl">
+    <header class="border-bottom mb-3 bg-light">
+        <div class="container py-3">
+            <h1 class="h3 mb-0">فرم ثبت‌نام آزمایشی</h1>
+        </div>
+    </header>
+
+    <div class="container pb-5">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/RegistrationApp.Web/Pages/_ViewImports.cshtml
+++ b/src/RegistrationApp.Web/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using RegistrationApp.Application.Contracts.Forms
+@namespace RegistrationApp.Web.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/RegistrationApp.Web/Pages/_ViewStart.cshtml
+++ b/src/RegistrationApp.Web/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/src/RegistrationApp.Web/Program.cs
+++ b/src/RegistrationApp.Web/Program.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using RegistrationApp.Application;
+using RegistrationApp.Application.Abstractions;
+using RegistrationApp.Application.Contracts.Registrations;
+using RegistrationApp.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddApplicationServices();
+builder.Services.AddInfrastructureServices();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.MapRazorPages();
+
+app.MapPost("/api/registrations/validate", (RegistrationRequest request, IRegistrationService service) =>
+{
+    var result = service.ValidateAndCreateRecord(request);
+    return result.Succeeded
+        ? Results.Ok(result.Record)
+        : Results.BadRequest(result.Errors);
+});
+
+app.Run();

--- a/src/RegistrationApp.Web/Properties/launchSettings.json
+++ b/src/RegistrationApp.Web/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5084",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/RegistrationApp.Web/RegistrationApp.Web.csproj
+++ b/src/RegistrationApp.Web/RegistrationApp.Web.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>RegistrationApp.Web</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RegistrationApp.Application\RegistrationApp.Application.csproj" />
+    <ProjectReference Include="..\RegistrationApp.Domain\RegistrationApp.Domain.csproj" />
+    <ProjectReference Include="..\RegistrationApp.Infrastructure\RegistrationApp.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/RegistrationApp.Web/appsettings.Development.json
+++ b/src/RegistrationApp.Web/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/RegistrationApp.Web/appsettings.json
+++ b/src/RegistrationApp.Web/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/RegistrationApp.Web/wwwroot/css/site.css
+++ b/src/RegistrationApp.Web/wwwroot/css/site.css
@@ -1,0 +1,37 @@
+body {
+    background-color: #f5f6fa;
+}
+
+.form-section {
+    background-color: #ffffff;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.75rem 1.5rem rgba(18, 38, 63, 0.05);
+    padding: 2rem;
+}
+
+.form-section h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+}
+
+.table-container {
+    background-color: #ffffff;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.75rem 1.5rem rgba(18, 38, 63, 0.05);
+    padding: 1.5rem;
+}
+
+.table thead {
+    background-color: #0d6efd;
+    color: #ffffff;
+}
+
+.required::after {
+    content: " *";
+    color: #dc3545;
+}
+
+#no-records {
+    color: #6c757d;
+}

--- a/src/RegistrationApp.Web/wwwroot/js/registration.js
+++ b/src/RegistrationApp.Web/wwwroot/js/registration.js
@@ -1,0 +1,247 @@
+(function () {
+    const form = document.getElementById('registration-form');
+    if (!form) {
+        return;
+    }
+
+    const clearBtn = document.getElementById('clear-storage');
+    const recordsTableBody = document.querySelector('#records-table tbody');
+    const noRecordsMessage = document.getElementById('no-records');
+    const recordCountBadge = document.getElementById('record-count');
+    const errorsContainer = document.getElementById('form-errors');
+    const definitionElement = document.getElementById('registration-form-definition');
+    const storageKey = 'registration-records';
+    const endpoint = form.dataset.endpoint;
+
+    const formDefinition = definitionElement?.textContent ? JSON.parse(definitionElement.textContent) : null;
+    const fieldErrorPrefixes = {
+        'Name.FirstName': 'firstName',
+        'Name.LastName': 'lastName',
+        'Email': 'email',
+        'PhoneNumber': 'phone',
+        'BirthDate': 'birthDate',
+        'Gender': 'gender',
+        'Address.City': 'city',
+        'Address.Full': 'address'
+    };
+
+    const readRecords = () => {
+        try {
+            const raw = window.localStorage.getItem(storageKey);
+            return raw ? JSON.parse(raw) : [];
+        } catch (error) {
+            console.error('خطا در خواندن اطلاعات از localStorage', error);
+            return [];
+        }
+    };
+
+    const writeRecords = (records) => {
+        try {
+            window.localStorage.setItem(storageKey, JSON.stringify(records));
+        } catch (error) {
+            console.error('خطا در ذخیره‌سازی در localStorage', error);
+        }
+    };
+
+    const formatDate = (isoString) => {
+        if (!isoString) {
+            return '-';
+        }
+
+        const date = new Date(isoString);
+        return new Intl.DateTimeFormat('fa-IR', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit'
+        }).format(date);
+    };
+
+    const renderRecords = () => {
+        const records = readRecords();
+        recordsTableBody.innerHTML = '';
+
+        if (!records.length) {
+            noRecordsMessage?.classList.remove('d-none');
+            if (recordCountBadge) {
+                recordCountBadge.textContent = '0';
+            }
+            return;
+        }
+
+        noRecordsMessage?.classList.add('d-none');
+        if (recordCountBadge) {
+            recordCountBadge.textContent = records.length.toString();
+        }
+
+        records
+            .sort((a, b) => new Date((b.createdAt ?? b.CreatedAt) || 0).getTime() - new Date((a.createdAt ?? a.CreatedAt) || 0).getTime())
+            .forEach((record, index) => {
+                const row = document.createElement('tr');
+                const fullName = record.fullName || [record.firstName, record.lastName].filter(Boolean).join(' ').trim() || '-';
+                const genderLine = record.genderDisplayName ? `<div class="text-muted small">${record.genderDisplayName}</div>` : '';
+                const email = record.email || '-';
+                const createdAtValue = record.createdAt ?? record.CreatedAt;
+
+                row.innerHTML = `
+                    <th scope="row">${index + 1}</th>
+                    <td>
+                        <div class="fw-semibold">${fullName}</div>
+                        ${genderLine}
+                    </td>
+                    <td>${email}</td>
+                    <td>${record.phoneNumber || '-'}</td>
+                    <td>${record.city || '-'}</td>
+                    <td>${formatDate(createdAtValue)}</td>`;
+
+                recordsTableBody.appendChild(row);
+            });
+    };
+
+    const formControls = () => Array.from(form.querySelectorAll('input, select, textarea'));
+
+    const markInvalidFields = () => {
+        formControls().forEach(control => {
+            if (!control.checkValidity()) {
+                control.classList.add('is-invalid');
+            } else {
+                control.classList.remove('is-invalid');
+            }
+        });
+    };
+
+    const clearFieldValidationStyles = () => {
+        formControls().forEach(control => control.classList.remove('is-invalid'));
+    };
+
+    const clearServerErrors = () => {
+        if (errorsContainer) {
+            errorsContainer.classList.add('d-none');
+            errorsContainer.innerHTML = '';
+        }
+    };
+
+    const showServerErrors = (errors) => {
+        if (!errorsContainer) {
+            return;
+        }
+
+        const messages = Array.isArray(errors) ? errors : [];
+        if (!messages.length) {
+            return;
+        }
+
+        errorsContainer.classList.remove('d-none');
+        const list = document.createElement('ul');
+        list.classList.add('mb-0');
+
+        messages.forEach(error => {
+            const listItem = document.createElement('li');
+            listItem.textContent = error.message || 'خطایی رخ داده است.';
+            list.appendChild(listItem);
+
+            if (error.code) {
+                const prefix = Object.keys(fieldErrorPrefixes).find(key => error.code.startsWith(key));
+                if (prefix) {
+                    const fieldId = fieldErrorPrefixes[prefix];
+                    const field = document.getElementById(fieldId);
+                    field?.classList.add('is-invalid');
+                }
+            }
+        });
+
+        errorsContainer.appendChild(list);
+    };
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        form.classList.add('was-validated');
+        clearServerErrors();
+        markInvalidFields();
+
+        if (!form.checkValidity()) {
+            return;
+        }
+
+        const formData = new FormData(form);
+        const payload = Object.fromEntries(formData.entries());
+        const requestBody = {
+            firstName: (payload.firstName || '').toString().trim(),
+            lastName: (payload.lastName || '').toString().trim(),
+            email: (payload.email || '').toString().trim(),
+            phoneNumber: (payload.phone || '').toString().trim(),
+            birthDate: (payload.birthDate || '').toString().trim(),
+            gender: (payload.gender || '').toString().trim(),
+            city: (payload.city || '').toString().trim(),
+            address: (payload.address || '').toString().trim()
+        };
+
+        try {
+            if (!endpoint) {
+                throw new Error('آدرس سرویس اعتبارسنجی یافت نشد.');
+            }
+
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                let errors;
+                try {
+                    errors = await response.json();
+                } catch {
+                    errors = [{ message: 'خطای ناشناخته‌ای رخ داده است.' }];
+                }
+                showServerErrors(errors);
+                return;
+            }
+
+            const record = await response.json();
+            const records = readRecords();
+            records.push(record);
+            writeRecords(records);
+
+            form.reset();
+            form.classList.remove('was-validated');
+            clearFieldValidationStyles();
+            clearServerErrors();
+            renderRecords();
+        } catch (error) {
+            console.error('خطا در ارتباط با سرویس اعتبارسنجی', error);
+            showServerErrors([{ message: 'امکان برقراری ارتباط با سرویس اعتبارسنجی وجود ندارد. لطفاً دوباره تلاش کنید.' }]);
+        }
+    });
+
+    form.addEventListener('input', (event) => {
+        const target = event.target;
+        if (target instanceof HTMLInputElement || target instanceof HTMLSelectElement || target instanceof HTMLTextAreaElement) {
+            if (target.checkValidity()) {
+                target.classList.remove('is-invalid');
+            }
+        }
+    });
+
+    clearBtn?.addEventListener('click', () => {
+        if (confirm('آیا از حذف همه اطلاعات مطمئن هستید؟')) {
+            writeRecords([]);
+            clearFieldValidationStyles();
+            clearServerErrors();
+            form.classList.remove('was-validated');
+            renderRecords();
+        }
+    });
+
+    renderRecords();
+
+    if (formDefinition) {
+        form.dataset.definition = JSON.stringify({
+            title: formDefinition.title,
+            fieldCount: formDefinition.sections?.flatMap(section => section.fields || []).length || 0
+        });
+    }
+})();


### PR DESCRIPTION
## Summary
- split the app into Domain, Application and Infrastructure and Web projects wired up in a solution and DI container
- add rich domain validation/value objects with an application service and API endpoint that normalizes registration data
- rebuild the Razor Page and client script to render from the form definition, call the validation API and persist sanitized records in localStorage
- document the architecture and usage instructions in the README
- reference Microsoft.Extensions.DependencyInjection in the application and infrastructure projects so IServiceCollection extensions resolve during build

## Testing
- dotnet build RegistrationApp.sln *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cef0883338832292a507112b892548